### PR TITLE
update 'payload' encoding

### DIFF
--- a/core/class/synologychat.class.php
+++ b/core/class/synologychat.class.php
@@ -91,7 +91,7 @@ class synologychatCmd extends cmd {
 				}
 			}
 			$post = array('text' => trim($_options['title'] . ' ' . $_options['message']));
-			$payload = str_replace('&', '%26', json_encode($post));
+			$payload = urlencode(json_encode($post));
 			$request_http->setPost('payload=' . $payload);
 			$retry = true;
 			$count = 0;
@@ -116,7 +116,7 @@ class synologychatCmd extends cmd {
 			if (isset($_options['files']) && count($_options['files']) > 0) {
 				foreach ($_options['files'] as $file) {
 					$post = array('file_url' => network::getNetworkAccess($eqLogic->getConfiguration('networkmode')) . '/plugins/synologychat/core/php/jeeFile.php?apikey=' . jeedom::getApiKey('synologychat') . '&file=' . urlencode($file));
-					$payload = str_replace('&', '%26', json_encode($post));
+					$payload = urlencode(json_encode($post));
 					$request_http->setPost('payload=' . $payload);
 					$retry = true;
 					$count = 0;


### PR DESCRIPTION
pour éviter la substitution de caractères spéciaux lors de la construction de la chaîne 'payload', j'ai remplacé le 'str_replace' par 'urlencode' aux deux endroits dans le code où il est utilisé.

Cela permet d'encoder tout type de chaîne (notamment quand c'est utilisé pour les notifications d'erreurs dans Jeedom où il y a souvent des caractères spéciaux type & + % @, et cela fonctionne également avec les emails et les urls à transmettre.

Le seul caractère qui n'est pas envoyé correctement (dans mes tests) est le guillemet mais il ne semble pas être envoyé par le formulaire (un scénario par exemple...) lorsqu'on regarde dans les logs du scénario, le " disparaît systématiquement...

A tester... :)