### PR TITLE
update $post to enable some specials characters in message and non du…

### DIFF
--- a/core/class/synologychat.class.php
+++ b/core/class/synologychat.class.php
@@ -90,7 +90,12 @@ class synologychatCmd extends cmd {
 					$_options['message'] .= '<' . $this->generateAskResponseLink($answer) . '&count=4|' . $answer . '> ';
 				}
 			}
-			$post = array('text' => trim($_options['title'] . ' ' . $_options['message']));
+			if ($_options['title'] === $_options['message']) {
+                                $post = array('text' => html_entity_decode(trim($_options['message']), ENT_QUOTES | ENT_HTML5));
+                        }
+                        else {
+                                $post = array('text' => html_entity_decode(trim("{$_options['title']} {$_options['message']}"), ENT_QUOTES | ENT_HTML5));
+                        }
 			$payload = urlencode(json_encode($post));
 			$request_http->setPost('payload=' . $payload);
 			$retry = true;


### PR DESCRIPTION
…plicated title + message

Je propose cette modification : 
- d'une part pour améliorer l'affichage notamment des logs qui contiennent des caractères spéciaux comme %, &apos, &quot etc...
- d'autre part le test de comparaison de title et message est là pour éviter le double affichage lors d'une capture d'une caméra par exemple qui affiche deux fois le texte car il est à la fois dans title et message, si les deux sont identiques, je n'en affiche qu'un : le contenu de 'message'.

Ayant testé pendant une dizaine de jours avec le code proposé sans erreur à ce jour, je propose la modification ici.
@++